### PR TITLE
Add script for applying a policy to all vhosts

### DIFF
--- a/scripts/_vhosts
+++ b/scripts/_vhosts
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 set -e -o pipefail
 

--- a/scripts/_vhosts
+++ b/scripts/_vhosts
@@ -1,6 +1,0 @@
-#!/usr/bin/env bash
-
-set -e -o pipefail
-
-rabbitmqctl list_vhosts |
-  tail -n +2

--- a/scripts/_vhosts
+++ b/scripts/_vhosts
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+set -e -o pipefail
+
+rabbitmqctl list_vhosts |
+  tail -n +2

--- a/scripts/apply-policy-to-all-vhosts
+++ b/scripts/apply-policy-to-all-vhosts
@@ -16,12 +16,14 @@
 
 set -e -o pipefail
 
-_vhosts | while read -r _vhost
-do
-  rabbitmqctl set_policy -p "$_vhost" \
-    --priority "${POLICY_PRIORITY:?must be set}" \
-    --apply-to "${POLICY_APPLY_TO:?must be set}" \
-    "${POLICY_NAME:?must be set}" \
-    "${POLICY_PATTERN:?must be set}" \
-    "${POLICY_DEFINITION:?must be set}"
-done
+rabbitmqctl list_vhosts |
+  tail -n +2 |
+  while read -r _vhost
+  do
+    rabbitmqctl set_policy -p "$_vhost" \
+      --priority "${POLICY_PRIORITY:?must be set}" \
+      --apply-to "${POLICY_APPLY_TO:?must be set}" \
+      "${POLICY_NAME:?must be set}" \
+      "${POLICY_PATTERN:?must be set}" \
+      "${POLICY_DEFINITION:?must be set}"
+  done

--- a/scripts/apply-policy-to-all-vhosts
+++ b/scripts/apply-policy-to-all-vhosts
@@ -16,11 +16,13 @@
 
 set -e -o pipefail
 
-rabbitmqctl list_vhosts |
+declare -r rabbitmqctl_cmd="${RABBITMQCTL:-rabbitmqctl}"
+
+"$rabbitmqctl_cmd" list_vhosts |
   tail -n +2 |
   while read -r _vhost
   do
-    rabbitmqctl set_policy -p "$_vhost" \
+    "$rabbitmqctl_cmd" set_policy -p "$_vhost" \
       --priority "${POLICY_PRIORITY:?must be set}" \
       --apply-to "${POLICY_APPLY_TO:?must be set}" \
       "${POLICY_NAME:?must be set}" \

--- a/scripts/apply-policy-to-all-vhosts
+++ b/scripts/apply-policy-to-all-vhosts
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+# Apply a single policy to all vhosts
+#
+# https://www.rabbitmq.com/parameters.html
+#
+# Example:
+#
+#       export POLICY_NAME='limit_hystrix_queues'
+#       export POLICY_PATTERN='spring.cloud.stream.hystrix.*'
+#       export POLICY_DEFINITION='{"max-length-bytes":100000}'
+#       export POLICY_PRIORITY='51'
+#       export POLICY_APPLY_TO='queues'
+#
+#       apply-policy-to-all-vhosts
+
+set -e -o pipefail
+
+_vhosts | while read -r _vhost
+do
+  rabbitmqctl set_policy -p "$_vhost" \
+    --name "${POLICY_NAME:?must be set}" \
+    --pattern "${POLICY_PATTERN:?must be set}" \
+    --definition "${POLICY_DEFINITION:?must be set}" \
+    --priority "${POLICY_PRIORITY:?must be set}" \
+    --apply-to "${POLICY_APPLY_TO:?must be set}"
+done

--- a/scripts/apply-policy-to-all-vhosts
+++ b/scripts/apply-policy-to-all-vhosts
@@ -19,9 +19,9 @@ set -e -o pipefail
 _vhosts | while read -r _vhost
 do
   rabbitmqctl set_policy -p "$_vhost" \
-    --name "${POLICY_NAME:?must be set}" \
-    --pattern "${POLICY_PATTERN:?must be set}" \
-    --definition "${POLICY_DEFINITION:?must be set}" \
     --priority "${POLICY_PRIORITY:?must be set}" \
-    --apply-to "${POLICY_APPLY_TO:?must be set}"
+    --apply-to "${POLICY_APPLY_TO:?must be set}" \
+    "${POLICY_NAME:?must be set}" \
+    "${POLICY_PATTERN:?must be set}" \
+    "${POLICY_DEFINITION:?must be set}"
 done

--- a/scripts/apply-policy-to-all-vhosts
+++ b/scripts/apply-policy-to-all-vhosts
@@ -16,13 +16,11 @@
 
 set -e -o pipefail
 
-declare -r rabbitmqctl_cmd="${RABBITMQCTL:-rabbitmqctl}"
-
-"$rabbitmqctl_cmd" list_vhosts |
+rabbitmqctl list_vhosts |
   tail -n +2 |
   while read -r _vhost
   do
-    "$rabbitmqctl_cmd" set_policy -p "$_vhost" \
+    rabbitmqctl set_policy -p "$_vhost" \
       --priority "${POLICY_PRIORITY:?must be set}" \
       --apply-to "${POLICY_APPLY_TO:?must be set}" \
       "${POLICY_NAME:?must be set}" \


### PR DESCRIPTION
This is an iteration on:

```sh
#!/bin/bash
vhosts=( $( /var/vcap/jobs/rabbitmq-server/packages/rabbitmq-server/bin/rabbitmqctl list_vhosts ) )
length=${#vhosts[@]}
 
echo ${length}
for i in `seq 3 ${length}`;
do
        /var/vcap/jobs/rabbitmq-server/packages/rabbitmq-server/bin/rabbitmqctl set_policy -p ${vhosts[$i]} --priority 51 policy ".*" '{"x-max-length":100000}'
done
```