### PR TITLE
Add missing vhost parameter

### DIFF
--- a/scripts/rebalance-queue-masters
+++ b/scripts/rebalance-queue-masters
@@ -31,7 +31,7 @@ sync_queue()
 get_queue_master()
 {
     local -r queue="$1"
-    rabbitmqctl -q list_queues name pid | grep -E "^$queue\>" | cut -f2 | sed -e 's/[><]//g' -e 's/\(\.[0-9]\+\)\{3\}//g'
+    rabbitmqctl -q -p "$vhost" list_queues name pid | grep -E "^$queue\>" | cut -f2 | sed -e 's/[><]//g' -e 's/\(\.[0-9]\+\)\{3\}//g'
 }
 
 ensure_node_health()


### PR DESCRIPTION
On get_queue_master the parameter vhost is not respected,
making it enter an infinity loop if you are using other
than the default vhost.