### PR TITLE
fix regex for get_queue_master

### DIFF
--- a/scripts/rebalance-queue-masters
+++ b/scripts/rebalance-queue-masters
@@ -31,7 +31,7 @@ sync_queue()
 get_queue_master()
 {
     local -r queue="$1"
-    rabbitmqctl -q -p "$vhost" list_queues name pid | grep -E "^$queue\>" | cut -f2 | sed -e 's/[><]//g' -e 's/\(\.[0-9]\+\)\{3\}//g'
+    rabbitmqctl -q -p "$vhost" list_queues name pid | grep -E "^$queue[[:space:]]" | cut -f2 | sed -e 's/[><]//g' -e 's/\(\.[0-9]\+\)\{3\}//g'
 }
 
 ensure_node_health()


### PR DESCRIPTION
we want to grep the exact queue name here. The old way would pick
anything that starts with the queue name (i.e. foo and foo.bar) and
the output from get_queue_master will include all the queues matched,
so it would enter a loop as it will never pick just one pid to compare
properly against the desired master pid expected.