### PR TITLE
rebalance-queue-masters - handle long hostnames being output on multiple lines

### DIFF
--- a/scripts/rebalance-queue-masters
+++ b/scripts/rebalance-queue-masters
@@ -81,7 +81,7 @@ set_temp_queue_policies()
 
         # List of nodes
         IFS=','
-        for tmp in $(rabbitmqctl eval 'rabbit_nodes:all_running().' | sed -e "s/[][']//g")
+        for tmp in $(rabbitmqctl eval 'rabbit_nodes:all_running().' | tr -d '\n ' | sed -e "s/[][']//g")
         do
             node_list[$tmp]=1
             node_master_count[$tmp]=0
@@ -246,7 +246,7 @@ validate()
 
     IFS=','
     local -i i=0
-    for node in $(rabbitmqctl eval 'rabbit_nodes:all_running().' | sed -e "s/[][']//g")
+    for node in $(rabbitmqctl eval 'rabbit_nodes:all_running().' | tr -d '\n ' | sed -e "s/[][']//g")
     do
         nodes[$i]="$node"
         (( i = i + 1 ))


### PR DESCRIPTION
The list of hostnames is created from the following command which can span multiple lines:
```
# rabbitmqctl eval 'rabbit_nodes:all_running().'
['rabbit@rabbitmq-exp-0.rabbitmq-exp.cornershop-exp-rabbitmq.svc.cluster.local',
 'rabbit@rabbitmq-exp-1.rabbitmq-exp.cornershop-exp-rabbitmq.svc.cluster.local',
 'rabbit@rabbitmq-exp-2.rabbitmq-exp.cornershop-exp-rabbitmq.svc.cluster.local']
```

This change removes eventual newlines in this output followed by an extra space at the beginning of the next line.

This fixes the following issue:
```
# ./rebalance.sh 
20190402-15:01:39 [INFO] Setting temporary policies on vhost: /
20190402-15:01:45 [ERROR] Node '
 rabbit@rabbitmq-exp-1.rabbitmq-exp.cornershop-exp-rabbitmq.svc.cluster.local' failed health check:
Error: operation node_health_check failed due to invalid node name (node: 
 rabbit@rabbitmq-exp-1.rabbitmq-exp.cornershop-exp-rabbitmq.svc.cluster.local reason: hostname_not_allowed).
If using FQDN node names, use the -l / --longnames argument
```