### PR TITLE
rebalance-queue-masters - fix calculation if queues are balanced

### DIFF
--- a/scripts/rebalance-queue-masters
+++ b/scripts/rebalance-queue-masters
@@ -132,10 +132,13 @@ set_temp_queue_policies()
         local -i node_with_most_queues_count=0
         local node_with_fewest_queues=''
         local -i node_with_fewest_queues_count=0
+        local total_queue_count=''
+        local -i total_queue_count=0
 
         for node in "${!node_master_count[@]}"
         do
             node_queue_count="${node_master_count[$node]}"
+            total_queue_count+="$node_queue_count"
 
             if [[ $first_iteration == 'true' ]]
             then
@@ -158,13 +161,12 @@ set_temp_queue_policies()
             fi
         done
 
-        # Diff between max and min
-        local -i diff="$((node_with_most_queues_count - node_with_fewest_queues_count))"
+        # upper bound for queues per host: total number of queues divided by number of hosts round up
+        local -i max_queues_desired_per_host="$(((total_queue_count / num_nodes) + (total_queue_count % num_nodes > 0)))"
 
-        # Exit if max-min diff is less than number of nodes
-        if (( diff <= num_nodes ))
+        if (( node_with_most_queues_count <= max_queues_desired_per_host ))
         then
-            echo "$(now) [INFO] Already Balanced. Exiting!"
+            echo "$(now) [INFO] Queues are balanced. Exiting!"
             exit 0
         fi
 


### PR DESCRIPTION
The calculation if balancing is needed is incorrect. In my tests I spun up a 3-node cluster with 6 queues in a 4-1-1 distribution, this was detected as balanced (4-1=3 <= 3) but obviously isn't.

I changed the approach to calculate an upper bound for the number of queues per host. As long as this isn't achieved, balancing is executed from the host with the most queues to the host with the least queues.
