### PR TITLE
fix re-balance script to parse out node name if it has an IP address

### DIFF
--- a/scripts/rebalance-queue-masters
+++ b/scripts/rebalance-queue-masters
@@ -43,7 +43,7 @@ get_queue_master()
 {
     local -r queue="$1"
     # shellcheck disable=SC1087
-    rabbitmqctl -q -p "$vhost" list_queues name pid | grep -E "^$queue[[:space:]]" | cut -f2 | sed -e 's/[><]//g' -e 's/\(\.[[:digit:]][[:digit:]]*\)\{3\}//g'
+    rabbitmqctl -q -p "$vhost" list_queues name pid | grep -E "^$queue[[:space:]]" | cut -f2 | sed -e 's/[><]//g' -e 's/\(\.[[:digit:]][[:digit:]]*\)\{3\}$//g'
 }
 
 ensure_node_health()
@@ -100,7 +100,7 @@ set_temp_queue_policies()
 
         # List of masters extracted from node_list + list_queues masters.
         IFS=$'\n'
-        for tmp in $(rabbitmqctl -q -p "$vhost" list_queues pid 2>&1 | grep -vE '^pid' | sed -e 's/[><]//g' -e 's/\(\.[[:digit:]][[:digit:]]*\)\{3\}//g' | sort | uniq -c)
+        for tmp in $(rabbitmqctl -q -p "$vhost" list_queues pid 2>&1 | grep -vE '^pid' | sed -e 's/[><]//g' -e 's/\(\.[[:digit:]][[:digit:]]*\)\{3\}$//g' | sort | uniq -c)
         do
             IFS="$orig_IFS"
             # shellcheck disable=SC2086
@@ -185,7 +185,7 @@ set_temp_queue_policies()
 
         IFS="$orig_IFS"
         local current_master=''
-        current_master="$(sed -e 's/[><]//g' -e 's/\(\.[[:digit:]][[:digit:]]*\)\{3\}//g' <<< "$pid")"
+        current_master="$(sed -e 's/[><]//g' -e 's/\(\.[[:digit:]][[:digit:]]*\)\{3\}$//g' <<< "$pid")"
         local new_master="$node_with_fewest_queues"
 
         # Move queue master to other node (if so)


### PR DESCRIPTION
If node name contains IPv4 address (ex: `rabbit@192.168.33.13`), re-balance script incorrectly parses out host name part:

```
20190829-16:21:34 [INFO] Updating queue master for queue 'test-queue-83' from 'rabbit@192' to 'rabbit@192.168.33.13'
20190829-16:21:34 [INFO] Setting policy "test-queue-83-ha-temp" for pattern "^test-queue-83$" to "{"ha-mode":"exactly","ha-params":1}" with priority "990" for vhost "/" ...
20190829-16:21:35 [INFO] Synchronising queue 'test-queue-83' in vhost '/' ...
20190829-16:21:35 [INFO] Setting policy "test-queue-83-ha-temp" for pattern "^test-queue-83$" to "{"ha-mode":"nodes","ha-params":["rabbit@192.168.33.13"]}" with priority "992" for vhost "/" ...
20190829-16:21:36 [INFO] Synchronising queue 'test-queue-83' in vhost '/' ...
20190829-16:21:36 [WARNING] queue master has not yet updated, wanted 'rabbit@192.168.33.13', got 'rabbit@192' (attempts: 1)
20190829-16:21:42 [WARNING] queue master has not yet updated, wanted 'rabbit@192.168.33.13', got 'rabbit@192' (attempts: 2)
```

