### PR TITLE
undeclared variable queue_exclude_regex_opt_set will result in  line …

### DIFF
--- a/scripts/rebalance-queue-masters
+++ b/scripts/rebalance-queue-masters
@@ -292,6 +292,7 @@ parse_options()
     local queue_regex_opt_set='false'
     local disable_health_check_opt_set='false'
     local max_count_opt_set='false'
+    local queue_exclude_regex_opt_set='false'
 
     while getopts 'dhc:p:r:x:' opt "$@"
     do


### PR DESCRIPTION
…335: queue_exclude_regex_opt_set: unbound variable when trying to run this script

Signed-off-by: Kristin Barkardottir <kristin.barkardottir@netapp.com>