### PR TITLE
Fix rabbitmq-env location in PCF

### DIFF
--- a/scripts/rabbitmq-collect-env
+++ b/scripts/rabbitmq-collect-env
@@ -181,6 +181,12 @@ init_environment()
         RABBITMQ_ENV='/var/vcap/jobs/rabbitmq-server/packages/rabbitmq-server/privbin/rabbitmq-env'
     fi
 
+    if [ -z "$RABBITMQ_ENV" ] && \
+        [ -f /var/vcap/jobs/rabbitmq-server/packages/rabbitmq-server/sbin/rabbitmq-env ]
+    then
+        RABBITMQ_ENV='/var/vcap/jobs/rabbitmq-server/packages/rabbitmq-server/sbin/rabbitmq-env'
+    fi
+
     if [ -d /var/vcap/jobs/rabbitmq-server/packages/rabbitmq-server/etc ]
     then
         rabbitmq_etc_dir='/var/vcap/jobs/rabbitmq-server/packages/rabbitmq-server/etc'


### PR DESCRIPTION
## Overview of changes

Fix location of `rabbitmq-env` binary. This changed in upstream, and the script was not detecting the new location, in the PCF context.

## Links to related issues / PRs / context

Fixes #42 